### PR TITLE
Add field for frequencies/technologies used in markers

### DIFF
--- a/backend/db.js
+++ b/backend/db.js
@@ -35,6 +35,7 @@ db.serialize(() => {
     color TEXT,
     tag TEXT,
     localita TEXT,
+    frequenze TEXT,
     timestamp DATETIME DEFAULT CURRENT_TIMESTAMP
   )`);
 
@@ -42,6 +43,7 @@ db.serialize(() => {
   db.run('ALTER TABLE markers ADD COLUMN color TEXT', () => {});
   db.run('ALTER TABLE markers ADD COLUMN tag TEXT', () => {});
   db.run('ALTER TABLE markers ADD COLUMN localita TEXT', () => {});
+  db.run('ALTER TABLE markers ADD COLUMN frequenze TEXT', () => {});
 
   db.run(`CREATE TABLE IF NOT EXISTS marker_images (
     id INTEGER PRIMARY KEY AUTOINCREMENT,

--- a/backend/markers/index.js
+++ b/backend/markers/index.js
@@ -12,7 +12,7 @@ const upload = multer({ storage: multer.memoryStorage() });
 const router = express.Router();
 
 function validateMarkerInput(req, res, next) {
-  const { lat, lng, descrizione, images, color, tags } = req.body;
+  const { lat, lng, descrizione, images, color, tags, frequenze } = req.body;
   if (
     typeof lat !== 'number' ||
     typeof lng !== 'number' ||
@@ -41,6 +41,9 @@ function validateMarkerInput(req, res, next) {
   }
   if (color && typeof color !== 'string') {
     return res.status(400).json({ error: 'Invalid color' });
+  }
+  if (frequenze && typeof frequenze !== 'string') {
+    return res.status(400).json({ error: 'Invalid frequenze' });
   }
   if (tags) {
     if (!Array.isArray(tags)) {
@@ -90,6 +93,7 @@ router.get('/', (req, res) => {
           color: row.color,
           tags: parsedTags,
           localita: row.localita,
+          frequenze: row.frequenze,
           timestamp: row.timestamp,
           images: [],
         };
@@ -137,6 +141,7 @@ router.get('/:id', (req, res) => {
       color: rows[0].color,
       tags: parsedTags,
       localita: rows[0].localita,
+      frequenze: rows[0].frequenze,
       timestamp: rows[0].timestamp,
       images: [],
     };
@@ -159,7 +164,7 @@ router.post(
   authorizeRoles('admin', 'editor'),
   validateMarkerInput,
   async (req, res, next) => {
-    const { lat, lng, descrizione, images, nome, autore, color, tags } = req.body;
+    const { lat, lng, descrizione, images, nome, autore, color, tags, frequenze } = req.body;
 
     let localita = null;
     try {
@@ -176,7 +181,7 @@ router.post(
     }
 
     db.run(
-      'INSERT INTO markers (lat, lng, descrizione, nome, autore, color, tag, localita) VALUES (?, ?, ?, ?, ?, ?, ?, ?)',
+      'INSERT INTO markers (lat, lng, descrizione, nome, autore, color, tag, localita, frequenze) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)',
       [
         lat,
         lng,
@@ -186,6 +191,7 @@ router.post(
         color || null,
         tags ? JSON.stringify(tags) : null,
         localita,
+        frequenze || null,
       ],
       function (err) {
         if (err) {
@@ -224,10 +230,10 @@ router.put(
   authorizeRoles('admin', 'editor'),
   validateMarkerInput,
   (req, res, next) => {
-    const { lat, lng, descrizione, images, nome, autore, color, tags } = req.body;
+    const { lat, lng, descrizione, images, nome, autore, color, tags, frequenze } = req.body;
     const id = req.params.id;
     db.run(
-      'UPDATE markers SET lat = ?, lng = ?, descrizione = ?, nome = ?, autore = ?, color = ?, tag = ? WHERE id = ?',
+      'UPDATE markers SET lat = ?, lng = ?, descrizione = ?, nome = ?, autore = ?, color = ?, tag = ?, frequenze = ? WHERE id = ?',
       [
         lat,
         lng,
@@ -236,6 +242,7 @@ router.put(
         autore || null,
         color || null,
         tags ? JSON.stringify(tags) : null,
+        frequenze || null,
         id,
       ],
       function (err) {

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -271,6 +271,7 @@ form.addEventListener('submit', (e) => {
   const marker = {
     nome: document.getElementById('markerName').value,
     descrizione: document.getElementById('markerDesc').value,
+    frequenze: document.getElementById('markerFreq').value,
     lat: parseFloat(document.getElementById('markerLat').value),
     lng: parseFloat(document.getElementById('markerLng').value),
     tags: Array.from(
@@ -416,6 +417,7 @@ function openModal(marker) {
   document.getElementById('markerId').value = marker.id || '';
   document.getElementById('markerName').value = marker.nome || '';
   document.getElementById('markerDesc').value = marker.descrizione || '';
+  document.getElementById('markerFreq').value = marker.frequenze || '';
   document.getElementById('markerLat').value = marker.lat;
   document.getElementById('markerLng').value = marker.lng;
   if (markerTagContainer) {
@@ -474,6 +476,9 @@ function createTagIcon(tags) {
 function openMarkerView(marker, leafletMarker) {
   document.getElementById('viewTitle').textContent = marker.nome || 'Marker';
   document.getElementById('viewDesc').textContent = marker.descrizione || '';
+  document.getElementById('viewFreq').textContent = marker.frequenze
+    ? `Frequenze: ${marker.frequenze}`
+    : '';
   document.getElementById('viewLocalita').textContent = marker.localita
     ? `Località: ${marker.localita}`
     : '';

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -206,6 +206,10 @@
           <textarea id="markerDesc"></textarea>
         </label>
         <label>
+          Frequenze / Tecnologie:
+          <input type="text" id="markerFreq" />
+        </label>
+        <label>
           Latitudine:
           <input type="number" step="any" id="markerLat" />
         </label>
@@ -257,6 +261,7 @@
       <div class="view-info">
         <h4 id="viewTitle"></h4>
         <p id="viewDesc"></p>
+        <p id="viewFreq"></p>
         <p id="viewLocalita"></p>
         <p id="viewTags"></p>
         <div id="viewActions" style="margin-top:1rem;"></div>


### PR DESCRIPTION
## Summary
- allow markers to store used frequencies/technologies
- expose new field through API and UI

## Testing
- `cd backend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68932f73772883278466b0bbf93a8938