### PR TITLE
Add bounding box marker loading and deduplication

### DIFF
--- a/backend/markers/index.js
+++ b/backend/markers/index.js
@@ -60,12 +60,22 @@ function validateMarkerInput(req, res, next) {
 
 router.get('/', (req, res) => {
   const tagFilter = req.query.tag;
+  const bbox = req.query.bbox;
   let sql = `SELECT m.*, mi.id as image_id, mi.url, mi.didascalia
                FROM markers m LEFT JOIN marker_images mi ON m.id = mi.marker_id`;
   const params = [];
+  const conditions = [];
   if (tagFilter) {
-    sql += ' WHERE m.tag LIKE ?';
+    conditions.push('m.tag LIKE ?');
     params.push(`%${tagFilter}%`);
+  }
+  if (bbox) {
+    const [south, west, north, east] = bbox.split(',').map(Number);
+    conditions.push('m.lat BETWEEN ? AND ? AND m.lng BETWEEN ? AND ?');
+    params.push(south, north, west, east);
+  }
+  if (conditions.length) {
+    sql += ' WHERE ' + conditions.join(' AND ');
   }
   db.all(sql, params, (err, rows) => {
     if (err) {


### PR DESCRIPTION
## Summary
- Support optional `bbox` parameter in marker list endpoint
- Fetch markers for visible map bounds and reload on map movement
- Track loaded marker IDs to avoid duplicate rendering across fetches

## Testing
- `cd backend && npm test >/tmp/test.log && tail -n 20 /tmp/test.log`


------
https://chatgpt.com/codex/tasks/task_e_689346e971b48327a80128a18957ad4e