### PR TITLE
chore: update default paths for database and media

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,9 +32,9 @@ Applicazione web che consente agli utenti di segnalare la posizione di una BTS t
 ## Personalizzazioni
 
 - Per cambiare la porta del server è possibile usare la variabile d'ambiente `PORT`.
-- Impostare `UPLOADS_DIR` per specificare la cartella in cui salvare le immagini (di default `backend/uploads`).
+- Impostare `UPLOADS_DIR` per specificare la cartella in cui salvare le immagini (di default `/opt/media`).
 - Impostare `ENABLE_MAP_CACHE=true` per abilitare il download periodico dell'estratto OSM dell'Italia; la funzione è disabilitata di default.
-- Impostare `DB_DIR` per specificare una cartella esterna in cui salvare il database SQLite.
+- Impostare `DB_DIR` per specificare una cartella esterna in cui salvare il database SQLite (di default `/opt/database`).
 
 ## Database standalone
 
@@ -44,7 +44,7 @@ Per eseguire il database come processo indipendente, utile per mantenerlo attivo
 npm run db
 ```
 
-Il database verrà creato nella cartella indicata da `DB_DIR` o, in mancanza, in `backend/`.
+Il database verrà creato nella cartella indicata da `DB_DIR` o, in mancanza, in `/opt/database`.
 
 ## Struttura del progetto
 

--- a/backend/README.md
+++ b/backend/README.md
@@ -20,5 +20,5 @@ Per motivi di performance il caching dell'estratto OpenStreetMap è disattivato 
 
 ## Configurazione del database
 
-- Impostare la variabile d'ambiente `DB_DIR` per utilizzare una cartella esterna dove salvare il file `data.sqlite`.
+- Impostare la variabile d'ambiente `DB_DIR` per utilizzare una cartella esterna dove salvare il file `data.sqlite` (di default `/opt/database`).
 - È possibile avviare il database come processo separato con `npm run db` nella cartella `backend`.

--- a/backend/config.js
+++ b/backend/config.js
@@ -1,9 +1,5 @@
-const path = require('path');
-
-const backendDir = __dirname;
-
-const defaultUploadsDir = path.join(backendDir, 'uploads');
-const defaultDbDir = path.join(backendDir, 'database');
+const defaultUploadsDir = '/opt/media';
+const defaultDbDir = '/opt/database';
 
 module.exports = {
   enableMapCache: process.env.ENABLE_MAP_CACHE === 'true',


### PR DESCRIPTION
## Summary
- set default database directory to `/opt/database`
- set default uploads directory to `/opt/media`
- document new default paths

## Testing
- `cd backend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68947c58333c8327a433bd6a15e75317