### PR TITLE
feat: allow admins to merge nearby markers

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,11 @@ Per importare marker da un file Excel scaricato dal sito AGCOM è disponibile lo
 
 ```bash
 cd backend
-npm run import-agcom -- path/to/file.xlsx
+ npm run import-agcom -- path/to/file.xlsx
 ```
 
  Lo script converte automaticamente le coordinate "LAT." e "LONG." in gradi decimali, salva l'"Ubicazione" nel campo `localita`, il "Bouquet" nella `descrizione` e la "FREQ. CENTRALE/PORTANTE" nel campo `frequenze`, assegnando il tag `Radio` per i tipi *FM* e *RD* oppure `TV` per i tipi *TD*. Se più righe presentano la stessa latitudine, longitudine e ubicazione, i relativi dettagli vengono uniti in un unico marker.
+
+## Funzionalità Admin
+
+Gli utenti con ruolo *admin* possono attivare la **Modalità unione** dalla pagina principale e selezionare più marker vicini. I marker scelti vengono fusi in uno solo, combinando descrizioni, tag, frequenze e immagini dei marker originali.

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -298,6 +298,12 @@
               <a href="admin.html" id="adminLink" style="display:none">Admin</a>
             </li>
             <li>
+              <a href="#" id="mergeModeBtn" style="display:none">Modalità unione</a>
+            </li>
+            <li>
+              <a href="#" id="mergeSelectedBtn" style="display:none">Unisci selezionati</a>
+            </li>
+            <li>
               <a href="about.html">About</a>
             </li>
           </ul>


### PR DESCRIPTION
## Summary
- allow admins to merge multiple markers via new `/markers/merge` endpoint
- add front-end merge mode to select and combine nearby markers
- document the feature in README

## Testing
- `cd backend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_6894889109b48327a704e7013e4268dc