### PR TITLE
Track source user in DB import scripts

### DIFF
--- a/backend/scripts/import-arpat-toscana.js
+++ b/backend/scripts/import-arpat-toscana.js
@@ -2,10 +2,30 @@ const xlsx = require('xlsx');
 const proj4 = require('proj4');
 const db = require('../db');
 
+const SOURCE = 'ARPAT Toscana';
+
 function runAsync(sql, params) {
   return new Promise((resolve, reject) => {
-    db.run(sql, params, err => {
-      if (err) reject(err); else resolve();
+    db.run(sql, params, function (err) {
+      if (err) reject(err);
+      else resolve({ lastID: this.lastID });
+    });
+  });
+}
+
+function getOrCreateUserId(username) {
+  return new Promise((resolve, reject) => {
+    db.get('SELECT id FROM users WHERE username = ?', [username], (err, row) => {
+      if (err) return reject(err);
+      if (row) return resolve(row.id);
+      db.run(
+        'INSERT INTO users (username, role) VALUES (?, ?)',
+        [username, 'user'],
+        function (err2) {
+          if (err2) return reject(err2);
+          resolve(this.lastID);
+        }
+      );
     });
   });
 }
@@ -67,6 +87,8 @@ async function main() {
   const sheet = wb.Sheets[wb.SheetNames[0]];
   const rows = xlsx.utils.sheet_to_json(sheet, { defval: null });
 
+  const userId = await getOrCreateUserId(SOURCE);
+
   for (const row of rows) {
     const nord = parseFloatSafe(row['Nord']);
     const est = parseFloatSafe(row['Est']);
@@ -93,9 +115,13 @@ async function main() {
     const tagsStr = tags.length ? JSON.stringify(tags) : null;
 
     try {
+      const result = await runAsync(
+        'INSERT INTO markers (lat, lng, descrizione, nome, autore, tag, localita, frequenze) VALUES (?, ?, ?, ?, ?, ?, ?, ?)',
+        [lat, lng, descrizione, nome, SOURCE, tagsStr, localita, frequenze]
+      );
       await runAsync(
-        'INSERT INTO markers (lat, lng, descrizione, nome, tag, localita, frequenze) VALUES (?, ?, ?, ?, ?, ?, ?)',
-        [lat, lng, descrizione, nome, tagsStr, localita, frequenze]
+        'INSERT INTO audit_logs (user_id, action, marker_id) VALUES (?, ?, ?)',
+        [userId, 'create', result.lastID]
       );
     } catch (err) {
       console.error('DB insert failed:', err.message);


### PR DESCRIPTION
## Summary
- attribute imported markers to a user named after the source database
- log audit entries for imported markers

## Testing
- `npm --prefix backend test`


------
https://chatgpt.com/codex/tasks/task_e_6898f3ca0ab48327bc9d4ffb5a2d94b6