### PR TITLE
Deduplicate LTE Italy imports by site ID

### DIFF
--- a/backend/scripts/import-lteitaly.js
+++ b/backend/scripts/import-lteitaly.js
@@ -69,12 +69,15 @@ async function main() {
     const parts = line.split(';');
     if (parts.length < 10) continue;
 
-    const lat = parseFloat(parts[7]);
-    const lng = parseFloat(parts[8]);
+    const key = parts[5];
+    if (!key || seen.has(key)) continue;
+
+    let lat = parseFloat(parts[7]);
+    let lng = parseFloat(parts[8]);
     if (Number.isNaN(lat) || Number.isNaN(lng)) continue;
 
-    const key = `${lat},${lng}`;
-    if (seen.has(key)) continue;
+    lat = Number(lat.toFixed(6));
+    lng = Number(lng.toFixed(6));
     seen.add(key);
 
     const tokens = parts[9].trim().split(/\s+/);


### PR DESCRIPTION
## Summary
- Deduplicate LTEItaly imports using the site identifier instead of coordinates
- Round site coordinates to 6 decimal places to reduce jitter

## Testing
- `cd backend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_6899f5549eb88327a0bc11ec49d4e5b3