### PR TITLE
Ensure LTE Italy import merges nearby sites consistently

### DIFF
--- a/backend/scripts/import-lteitaly.js
+++ b/backend/scripts/import-lteitaly.js
@@ -86,10 +86,10 @@ async function main() {
     let lng = parseFloat(parts[8]);
     if (Number.isNaN(lat) || Number.isNaN(lng)) continue;
 
-    const rawLat = lat;
     const latDeg = roundMeters / 111320; // approx meters per degree latitude
-    const lngDeg = roundMeters / (111320 * Math.cos((rawLat * Math.PI) / 180));
     lat = Math.round(lat / latDeg) * latDeg;
+    const latRad = (lat * Math.PI) / 180;
+    const lngDeg = roundMeters / (111320 * Math.cos(latRad));
     lng = Math.round(lng / lngDeg) * lngDeg;
     lat = Number(lat.toFixed(6));
     lng = Number(lng.toFixed(6));


### PR DESCRIPTION
## Summary
- Fix import-lteitaly merging by calculating longitude rounding using the normalized latitude to prevent minute differences.

## Testing
- `npm test`
- Manual import with two sites <10m apart verifying single merged marker

------
https://chatgpt.com/codex/tasks/task_e_689a33deee1483279f34d417fc078f76