### PR TITLE
Add radius proximity check to import scripts

### DIFF
--- a/backend/scripts/import-agcom.js
+++ b/backend/scripts/import-agcom.js
@@ -1,5 +1,6 @@
 const xlsx = require('xlsx');
 const db = require('../db');
+const { findNearbyMarker } = require('./utils');
 
 const SOURCE = 'AGCOM';
 
@@ -50,8 +51,9 @@ function getOrCreateUserId(username) {
 
 async function main() {
   const filePath = process.argv[2];
+  const radiusMeters = parseFloat(process.argv[3]) || 10;
   if (!filePath) {
-    console.error('Usage: node scripts/import-agcom.js <file.xlsx>');
+    console.error('Usage: node scripts/import-agcom.js <file.xlsx> [radiusMeters=10]');
     process.exit(1);
   }
 
@@ -93,6 +95,8 @@ async function main() {
   }
 
   for (const marker of markers.values()) {
+    const existing = await findNearbyMarker(marker.lat, marker.lng, radiusMeters);
+    if (existing) continue;
     const descrizione = Array.from(marker.descrizioni).join(' | ');
     const frequenze = Array.from(marker.frequenze).join(', ');
     const tags = marker.tags.size ? JSON.stringify(Array.from(marker.tags)) : null;

--- a/backend/scripts/import-aria-veneto.js
+++ b/backend/scripts/import-aria-veneto.js
@@ -1,6 +1,7 @@
 const xlsx = require('xlsx');
 const proj4 = require('proj4');
 const db = require('../db');
+const { findNearbyMarker } = require('./utils');
 
 const SOURCE = 'ARIA Veneto';
 
@@ -92,8 +93,9 @@ function mapTags(gestore) {
 
 async function main() {
   const filePath = process.argv[2];
+  const radiusMeters = parseFloat(process.argv[3]) || 10;
   if (!filePath) {
-    console.error('Usage: node scripts/import-aria-veneto.js <file>');
+    console.error('Usage: node scripts/import-aria-veneto.js <file> [radiusMeters=10]');
     process.exit(1);
   }
 
@@ -109,6 +111,9 @@ async function main() {
       console.warn('Skipping row due to invalid coordinates');
       continue;
     }
+
+    const existing = await findNearbyMarker(lat, lng, radiusMeters);
+    if (existing) continue;
 
     const gestore = row['gestore'] || null;
     const tags = mapTags(gestore);

--- a/backend/scripts/import-arpat-toscana.js
+++ b/backend/scripts/import-arpat-toscana.js
@@ -1,6 +1,7 @@
 const xlsx = require('xlsx');
 const proj4 = require('proj4');
 const db = require('../db');
+const { findNearbyMarker } = require('./utils');
 
 const SOURCE = 'ARPAT Toscana';
 
@@ -78,8 +79,9 @@ function mapTags(tipologia, gestore) {
 
 async function main() {
   const filePath = process.argv[2];
+  const radiusMeters = parseFloat(process.argv[3]) || 10;
   if (!filePath) {
-    console.error('Usage: node scripts/import-arpat-toscana.js <file.xlsx>');
+    console.error('Usage: node scripts/import-arpat-toscana.js <file.xlsx> [radiusMeters=10]');
     process.exit(1);
   }
 
@@ -102,6 +104,9 @@ async function main() {
       console.warn('Skipping row due to failed coordinate conversion');
       continue;
     }
+
+    const existing = await findNearbyMarker(lat, lng, radiusMeters);
+    if (existing) continue;
 
     const localita = row['Indirizzo'] || null;
     const frequenze = row['Tecnologia'] || null;

--- a/backend/scripts/utils.js
+++ b/backend/scripts/utils.js
@@ -1,0 +1,38 @@
+const db = require('../db');
+
+function haversineDistance(lat1, lng1, lat2, lng2) {
+  const R = 6371000; // meters
+  const phi1 = (lat1 * Math.PI) / 180;
+  const phi2 = (lat2 * Math.PI) / 180;
+  const dphi = ((lat2 - lat1) * Math.PI) / 180;
+  const dlambda = ((lng2 - lng1) * Math.PI) / 180;
+  const a =
+    Math.sin(dphi / 2) * Math.sin(dphi / 2) +
+    Math.cos(phi1) * Math.cos(phi2) *
+      Math.sin(dlambda / 2) * Math.sin(dlambda / 2);
+  const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+  return R * c;
+}
+
+function findNearbyMarker(lat, lng, radiusMeters) {
+  return new Promise((resolve, reject) => {
+    const latDeg = radiusMeters / 111320; // approx meters per degree lat
+    const latRad = (lat * Math.PI) / 180;
+    const lngDeg = radiusMeters / (111320 * Math.cos(latRad));
+    const params = [lat - latDeg, lat + latDeg, lng - lngDeg, lng + lngDeg];
+    db.all(
+      'SELECT id, lat, lng, descrizione FROM markers WHERE lat BETWEEN ? AND ? AND lng BETWEEN ? AND ?',
+      params,
+      (err, rows) => {
+        if (err) return reject(err);
+        for (const row of rows) {
+          const d = haversineDistance(lat, lng, row.lat, row.lng);
+          if (d <= radiusMeters) return resolve(row);
+        }
+        resolve(null);
+      }
+    );
+  });
+}
+
+module.exports = { findNearbyMarker };


### PR DESCRIPTION
## Summary
- introduce shared `findNearbyMarker` utility for radius-based deduplication
- skip inserting markers when an existing marker is found within the given radius across all import scripts

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689dda10ea508327a5118921363811c6