### PR TITLE
fix: reinitialize tab component safely

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -740,6 +740,8 @@ function openMarkerView(marker, leafletMarker) {
     if (viewTagTabsContainer) viewTagTabsContainer.style.display = 'block';
     viewDesc.style.display = 'none';
     viewFreq.style.display = 'none';
+    const existingTabs = M.Tabs.getInstance(viewTagTabs);
+    if (existingTabs) existingTabs.destroy();
     viewTagTabs.innerHTML = '';
     viewTagContents.innerHTML = '';
     tags.forEach((tag, i) => {


### PR DESCRIPTION
## Summary
- prevent Materialize tab errors when viewing markers with multiple tags

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a5aa02b0208327a24a48cd4c706adf