### PR TITLE
Hide Materialize tabs indicator

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -266,6 +266,10 @@
         /* Ridotto da -140% */
         transform-origin: 0 0;
       }
+
+      .tabs .indicator {
+        display: none;
+      }
     </style>
   </head>
   <body>


### PR DESCRIPTION
## Summary
- Hide Materialize tab slider using CSS

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a5ad019590832787c8fd3858153cc8